### PR TITLE
fix: deny virt

### DIFF
--- a/src/bin/wasi-virt.rs
+++ b/src/bin/wasi-virt.rs
@@ -126,10 +126,15 @@ fn main() -> Result<()> {
     virt_opts.clocks(args.allow_clocks.unwrap_or(allow_all));
 
     // http
-    virt_opts.clocks(args.allow_http.unwrap_or(allow_all));
+    virt_opts.http(args.allow_http.unwrap_or(allow_all));
+
+    // TODO: These need completing
 
     // random
-    virt_opts.clocks(args.allow_random.unwrap_or(allow_all));
+    // virt_opts.random(args.allow_random.unwrap_or(allow_all));
+
+    // sockets
+    // virt_opts.sockets(args.allow_sockets.unwrap_or(allow_all));
 
     // stdio
     virt_opts

--- a/src/virt_deny.rs
+++ b/src/virt_deny.rs
@@ -1,0 +1,148 @@
+use anyhow::Result;
+use walrus::{Module, ValType};
+
+use crate::walrus_ops::add_stub_exported_func;
+
+// set exports to deny clock access
+pub(crate) fn deny_clocks_virt(module: &mut Module) -> Result<()> {
+    add_stub_exported_func(
+        module,
+        "wasi:clocks/monotonic-clock#now",
+        vec![],
+        vec![ValType::I64],
+    )?;
+    add_stub_exported_func(
+        module,
+        "wasi:clocks/monotonic-clock#resolution",
+        vec![],
+        vec![ValType::I64],
+    )?;
+    add_stub_exported_func(
+        module,
+        "wasi:clocks/monotonic-clock#subscribe",
+        vec![ValType::I64, ValType::I32],
+        vec![ValType::I32],
+    )?;
+
+    add_stub_exported_func(
+        module,
+        "wasi:clocks/wall-clock#now",
+        vec![],
+        vec![ValType::I32],
+    )?;
+    add_stub_exported_func(
+        module,
+        "wasi:clocks/wall-clock#resolution",
+        vec![],
+        vec![ValType::I32],
+    )?;
+    add_stub_exported_func(
+        module,
+        "wasi:clocks/wall-clock#subscribe",
+        vec![ValType::I64, ValType::I32],
+        vec![ValType::I32],
+    )?;
+
+    add_stub_exported_func(
+        module,
+        "wasi:clocks/timezone#display",
+        vec![ValType::I32, ValType::I64, ValType::I32],
+        vec![ValType::I32],
+    )?;
+    add_stub_exported_func(
+        module,
+        "cabi_post_wasi:clocks/timezone#display",
+        vec![ValType::I32],
+        vec![],
+    )?;
+    add_stub_exported_func(
+        module,
+        "wasi:clocks/timezone#utc-offset",
+        vec![ValType::I32, ValType::I64, ValType::I32],
+        vec![ValType::I32],
+    )?;
+    add_stub_exported_func(
+        module,
+        "wasi:clocks/timezone#drop-timezone",
+        vec![ValType::I32],
+        vec![],
+    )?;
+
+    Ok(())
+}
+
+pub(crate) fn deny_http_virt(module: &mut Module) -> Result<()> {
+    add_stub_exported_func(
+        module,
+        "wasi:http/incoming-handler#handle",
+        vec![ValType::I32, ValType::I32],
+        vec![],
+    )?;
+    add_stub_exported_func(
+        module,
+        "wasi:http/outgoing-handler#handle",
+        vec![
+            ValType::I32,
+            ValType::I32,
+            ValType::I32,
+            ValType::I32,
+            ValType::I32,
+            ValType::I32,
+            ValType::I32,
+            ValType::I32,
+        ],
+        vec![ValType::I32],
+    )?;
+
+    // TODO: This needs completing
+
+    Ok(())
+}
+
+pub(crate) fn deny_random_virt(module: &mut Module) -> Result<()> {
+    add_stub_exported_func(
+        module,
+        "wasi:random/random#get-random-bytes",
+        vec![ValType::I64],
+        vec![ValType::I32],
+    )?;
+    add_stub_exported_func(
+        module,
+        "wasi:random/random#get-random-u64",
+        vec![],
+        vec![ValType::I64],
+    )?;
+    add_stub_exported_func(
+        module,
+        "wasi:random/insecure#get-insecure-random-bytes",
+        vec![ValType::I64],
+        vec![ValType::I32],
+    )?;
+    add_stub_exported_func(
+        module,
+        "wasi:random/insecure#get-insecure-random-u64",
+        vec![],
+        vec![ValType::I64],
+    )?;
+    add_stub_exported_func(
+        module,
+        "wasi:random/insecure-seed#insecure-seed",
+        vec![ValType::I64],
+        vec![ValType::I32],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn deny_exit_virt(module: &mut Module) -> Result<()> {
+    add_stub_exported_func(
+        module,
+        "wasi:cli-base/exit#exit",
+        vec![ValType::I32],
+        vec![],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn deny_sockets_virt(module: &mut Module) -> Result<()> {
+    todo!();
+}

--- a/src/virt_io.rs
+++ b/src/virt_io.rs
@@ -911,6 +911,7 @@ pub(crate) fn strip_io_virt(module: &mut Module) -> Result<()> {
 }
 
 pub(crate) fn strip_sockets_virt(module: &mut Module) -> Result<()> {
+    stub_sockets_virt(module)?;
     remove_exported_func(module, "wasi:sockets/ip-name-lookup#resolve-addresses")?;
     remove_exported_func(module, "wasi:sockets/ip-name-lookup#resolve-next-address")?;
     remove_exported_func(

--- a/src/walrus_ops.rs
+++ b/src/walrus_ops.rs
@@ -115,11 +115,20 @@ pub(crate) fn add_stub_exported_func(
     params: Vec<ValType>,
     results: Vec<ValType>,
 ) -> Result<()> {
+    let exported_fn = module.exports.iter().find(|expt| expt.name == export_name);
+
     let mut builder = FunctionBuilder::new(&mut module.types, &params, &results);
     builder.func_body().unreachable();
     let local_func = builder.local_func(vec![]);
     let fid = module.funcs.add_local(local_func);
-    module.exports.add(export_name, ExportItem::Function(fid));
+
+    // if it exists, replace it
+    if let Some(exported_fn) = exported_fn {
+        let export = module.exports.get_mut(exported_fn.id());
+        export.item = ExportItem::Function(fid);
+    } else {
+        module.exports.add(export_name, ExportItem::Function(fid));
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This fixes some of the remaining "virt deny" cases. These are APIs for interfaces where we do not need pass-through, so we do not implement them in the virtual adapter - and thus instead dynamically create the stub export functions that deny access.

This PR leaves in some todo itesm to flesh out the full denial virtualization for HTTP, Random and Sockets, down to filling in the remaining parts of these function definitions (which ideally would be auto generated as well).