### PR TITLE
add rust-toolchain.toml per dependency on nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Using WASI Virt, those specific file paths can be mounted and virtualized into t
 
 ## Basic Usage
 
-Make sure to run Cargo nightly (`rustup default nightly`).
+Note: This project requires [Cargo nightly](./rust-toolchain.toml).
 
 Then:
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Adds rust-toolchain.toml to track required toolchain config.  Users then don't necessarily need to set their global default to nightly when building this project.

There are more config opportunities [with this file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file), but I wanted to scope this PR to just the nightly channel config. 