### PR TITLE
Update wasm-opt and cap-std dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,9 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88e341d15ac1029aadce600be764a1a1edafe40e03cde23285bc1d261b3a4866"
 dependencies = [
- "cap-primitives 2.0.1",
- "cap-std 2.0.1",
- "io-lifetimes 2.0.3",
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
  "windows-sys 0.52.0",
 ]
 
@@ -217,27 +217,10 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434168fe6533055f0f4204039abe3ff6d7db338ef46872a5fa39e9d5ad5ab7a9"
 dependencies = [
- "cap-primitives 2.0.1",
- "cap-std 2.0.1",
- "rustix 0.38.31",
+ "cap-primitives",
+ "cap-std",
+ "rustix",
  "smallvec",
-]
-
-[[package]]
-name = "cap-primitives"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b6df5b295dca8d56f35560be8c391d59f0420f72e546997154e24e765e6451"
-dependencies = [
- "ambient-authority",
- "fs-set-times 0.19.2",
- "io-extras 0.17.4",
- "io-lifetimes 1.0.11",
- "ipnet",
- "maybe-owned",
- "rustix 0.37.27",
- "windows-sys 0.48.0",
- "winx 0.35.1",
 ]
 
 [[package]]
@@ -247,14 +230,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe16767ed8eee6d3f1f00d6a7576b81c226ab917eb54b96e5f77a5216ef67abb"
 dependencies = [
  "ambient-authority",
- "fs-set-times 0.20.1",
- "io-extras 0.18.1",
- "io-lifetimes 2.0.3",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 0.38.31",
+ "rustix",
  "windows-sys 0.52.0",
- "winx 0.36.3",
+ "winx",
 ]
 
 [[package]]
@@ -269,26 +252,14 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3373a62accd150b4fcba056d4c5f3b552127f0ec86d3c8c102d60b978174a012"
-dependencies = [
- "cap-primitives 1.0.15",
- "io-extras 0.17.4",
- "io-lifetimes 1.0.11",
- "rustix 0.37.27",
-]
-
-[[package]]
-name = "cap-std"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "593db20e4c51f62d3284bae7ee718849c3214f93a3b94ea1899ad85ba119d330"
 dependencies = [
- "cap-primitives 2.0.1",
- "io-extras 0.18.1",
- "io-lifetimes 2.0.3",
- "rustix 0.38.31",
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix",
 ]
 
 [[package]]
@@ -298,11 +269,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03261630f291f425430a36f38c847828265bc928f517cdd2004c56f4b02f002b"
 dependencies = [
  "ambient-authority",
- "cap-primitives 2.0.1",
+ "cap-primitives",
  "iana-time-zone",
  "once_cell",
- "rustix 0.38.31",
- "winx 0.36.3",
+ "rustix",
+ "winx",
 ]
 
 [[package]]
@@ -723,7 +694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
- "rustix 0.38.31",
+ "rustix",
  "windows-sys 0.52.0",
 ]
 
@@ -752,23 +723,12 @@ dependencies = [
 
 [[package]]
 name = "fs-set-times"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d167b646a876ba8fda6b50ac645cfd96242553cbaf0ca4fccaa39afcbf0801f"
-dependencies = [
- "io-lifetimes 1.0.11",
- "rustix 0.38.31",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "fs-set-times"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "033b337d725b97690d86893f9de22b67b80dcc4e9ad815f348254c38119db8fb"
 dependencies = [
- "io-lifetimes 2.0.3",
- "rustix 0.38.31",
+ "io-lifetimes",
+ "rustix",
  "windows-sys 0.52.0",
 ]
 
@@ -1030,33 +990,12 @@ dependencies = [
 
 [[package]]
 name = "io-extras"
-version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde93d48f0d9277f977a333eca8313695ddd5301dc96f7e02aeddcb0dd99096f"
-dependencies = [
- "io-lifetimes 1.0.11",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "io-extras"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c301e73fb90e8a29e600a9f402d095765f74310d582916a952f618836a1bd1ed"
 dependencies = [
- "io-lifetimes 2.0.3",
+ "io-lifetimes",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1158,12 +1097,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
@@ -1201,7 +1134,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.31",
+ "rustix",
 ]
 
 [[package]]
@@ -1440,22 +1373,6 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes 1.0.11",
- "itoa",
- "libc",
- "linux-raw-sys 0.3.8",
- "once_cell",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
@@ -1464,7 +1381,7 @@ dependencies = [
  "errno",
  "itoa",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys",
  "once_cell",
  "windows-sys 0.52.0",
 ]
@@ -1682,12 +1599,12 @@ checksum = "0682e006dd35771e392a6623ac180999a9a854b1d4a6c12fb2e804941c2b1f58"
 dependencies = [
  "bitflags 2.4.2",
  "cap-fs-ext",
- "cap-std 2.0.1",
+ "cap-std",
  "fd-lock",
- "io-lifetimes 2.0.3",
- "rustix 0.38.31",
+ "io-lifetimes",
+ "rustix",
  "windows-sys 0.52.0",
- "winx 0.36.3",
+ "winx",
 ]
 
 [[package]]
@@ -1704,7 +1621,7 @@ checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "rustix 0.38.31",
+ "rustix",
  "windows-sys 0.52.0",
 ]
 
@@ -1987,13 +1904,13 @@ dependencies = [
  "async-trait",
  "cap-fs-ext",
  "cap-rand",
- "cap-std 2.0.1",
+ "cap-std",
  "cap-time-ext",
- "fs-set-times 0.20.1",
- "io-extras 0.18.1",
- "io-lifetimes 2.0.3",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
  "once_cell",
- "rustix 0.38.31",
+ "rustix",
  "system-interface",
  "tracing",
  "wasi-common",
@@ -2009,10 +1926,10 @@ dependencies = [
  "anyhow",
  "bitflags 2.4.2",
  "cap-rand",
- "cap-std 2.0.1",
- "io-extras 0.18.1",
+ "cap-std",
+ "io-extras",
  "log",
- "rustix 0.38.31",
+ "rustix",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -2025,7 +1942,7 @@ name = "wasi-virt"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cap-std 1.0.15",
+ "cap-std",
  "clap",
  "heck 0.4.1",
  "serde",
@@ -2162,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt"
-version = "0.114.2"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effbef3bd1dde18acb401f73e740a6f3d4a1bc651e9773bddc512fe4d8d68f67"
+checksum = "fc942673e7684671f0c5708fc18993569d184265fd5223bb51fc8e5b9b6cfd52"
 dependencies = [
  "anyhow",
  "libc",
@@ -2178,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-cxx-sys"
-version = "0.114.2"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c09e24eb283919ace2ed5733bda4842a59ce4c8de110ef5c6d98859513d17047"
+checksum = "8c57b28207aa724318fcec6575fe74803c23f6f266fce10cbc9f3f116762f12e"
 dependencies = [
  "anyhow",
  "cxx",
@@ -2190,9 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-sys"
-version = "0.114.2"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f2f817bed2e8d65eb779fa37317e74de15585751f903c9118342d1970703a4"
+checksum = "8a1cce564dc768dacbdb718fc29df2dba80bd21cb47d8f77ae7e3d95ceb98cbe"
 dependencies = [
  "anyhow",
  "cc",
@@ -2296,7 +2213,7 @@ dependencies = [
  "bincode",
  "directories-next",
  "log",
- "rustix 0.38.31",
+ "rustix",
  "serde",
  "serde_derive",
  "sha2",
@@ -2399,7 +2316,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
- "rustix 0.38.31",
+ "rustix",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
  "windows-sys 0.52.0",
@@ -2421,7 +2338,7 @@ dependencies = [
  "log",
  "object",
  "rustc-demangle",
- "rustix 0.38.31",
+ "rustix",
  "serde",
  "serde_derive",
  "target-lexicon",
@@ -2440,7 +2357,7 @@ checksum = "babc65e64ab0dd4e1ce65624db64e24ed0fbdebb16148729173fa0da9f70e53c"
 dependencies = [
  "object",
  "once_cell",
- "rustix 0.38.31",
+ "rustix",
  "wasmtime-versioned-export-macros",
 ]
 
@@ -2473,7 +2390,7 @@ dependencies = [
  "memoffset",
  "paste",
  "psm",
- "rustix 0.38.31",
+ "rustix",
  "sptr",
  "wasm-encoder 0.38.1",
  "wasmtime-asm-macros",
@@ -2522,16 +2439,16 @@ dependencies = [
  "cap-fs-ext",
  "cap-net-ext",
  "cap-rand",
- "cap-std 2.0.1",
+ "cap-std",
  "cap-time-ext",
- "fs-set-times 0.20.1",
+ "fs-set-times",
  "futures",
- "io-extras 0.18.1",
- "io-lifetimes 2.0.3",
+ "io-extras",
+ "io-lifetimes",
  "libc",
  "log",
  "once_cell",
- "rustix 0.38.31",
+ "rustix",
  "system-interface",
  "thiserror",
  "tokio",
@@ -2847,17 +2764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1dbce9e90e5404c5a52ed82b1d13fc8cfbdad85033b6f57546ffd1265f8451"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winx"
-version = "0.35.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c52a121f0fbf9320d5f2a9a5d82f6cb7557eda5e8b47fc3e7f359ec866ae960"
-dependencies = [
- "bitflags 1.3.2",
- "io-lifetimes 1.0.11",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ toml = "0.8"
 walrus = "0.20.3"
 wasm-compose = "0.5.5"
 wasm-metadata = "0.10.20"
-wasm-opt = "0.114.2"
+wasm-opt = "0.116.0"
 wit-component = "0.21.0"
 
 [build-dependencies]
@@ -44,7 +44,7 @@ anyhow = "1"
 
 [dev-dependencies]
 anyhow = "1"
-cap-std = "1.0.12"
+cap-std = "2.0.0"
 heck = { version = "0.4" }
 tokio = { version = "1.30.0", features = ["macros"] }
 wasmtime = { version = "17.0.1", features = ["component-model"] }


### PR DESCRIPTION
Update to the latest wasm-opt and the cap-std used in Wasmtime.