### PR TITLE
fix: add exit to allow-all

### DIFF
--- a/src/bin/wasi-virt.rs
+++ b/src/bin/wasi-virt.rs
@@ -152,7 +152,7 @@ fn main() -> Result<()> {
     virt_opts.stdio().stderr(stderr);
 
     // exit
-    virt_opts.exit(args.allow_exit.unwrap_or_default());
+    virt_opts.exit(args.allow_exit.unwrap_or(allow_all));
 
     // env options
     let env = virt_opts.env();


### PR DESCRIPTION
Resolves https://github.com/bytecodealliance/WASI-Virt/issues/38 in ensuring exit is allowed for `--allow-all` in the CLI.