### PR TITLE
fix: disable dwarf on debug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ impl WasiVirt {
     }
 
     pub fn finish(&mut self) -> Result<VirtResult> {
-        let mut config = walrus::ModuleConfig::new();
+        let config = walrus::ModuleConfig::new();
         let mut module = if self.debug {
             config.parse(VIRT_ADAPTER_DEBUG)
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,9 +131,6 @@ impl WasiVirt {
 
     pub fn finish(&mut self) -> Result<VirtResult> {
         let mut config = walrus::ModuleConfig::new();
-        if self.debug {
-            config.generate_dwarf(true);
-        }
         let mut module = if self.debug {
             config.parse(VIRT_ADAPTER_DEBUG)
         } else {


### PR DESCRIPTION
When running `wasi-virt --debug` having the DWARF output enabled for Walrus is giving a segfault. Disabling the debug output at least gets debug working again.