### PR TITLE
chore: keep name section in debug builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,7 @@ impl WasiVirt {
             OptimizationOptions::new_opt_level_2()
                 .shrink_level(ShrinkLevel::Level1)
                 .enable_feature(Feature::All)
+                .debug_info(self.debug)
                 .run(&tmp_input, &tmp_output)
                 .with_context(|| "Unable to apply wasm-opt optimization to virt. This can be disabled with wasm_opt: false.")
                 .or_else(|e| {


### PR DESCRIPTION
Keeping the name section in the final virt module is really helpful while debugging the wasi-virt crash.