### PR TITLE
fix: truly respect `--allow-all` to allow all components

### DIFF
--- a/src/bin/wasi-virt.rs
+++ b/src/bin/wasi-virt.rs
@@ -28,26 +28,26 @@ struct Args {
 
     // CLOCKS
     /// Enable clocks
-    #[arg(long, action = ArgAction::SetTrue)]
+    #[arg(long, default_missing_value="true", num_args=0..=1)]
     allow_clocks: Option<bool>,
 
     /// Allow the component to exit
-    #[arg(long, action = ArgAction::SetTrue)]
+    #[arg(long, default_missing_value="true", num_args=0..=1)]
     allow_exit: Option<bool>,
 
     // HTTP
     /// Enable HTTP
-    #[arg(long, action = ArgAction::SetTrue)]
+    #[arg(long, default_missing_value="true", num_args=0..=1)]
     allow_http: Option<bool>,
 
     // RANDOM
     /// Enable Random
-    #[arg(long, action = ArgAction::SetTrue)]
+    #[arg(long, default_missing_value="true", num_args=0..=1)]
     allow_random: Option<bool>,
 
     // SOCKETS
     /// Enable Sockets
-    #[arg(long, action = ArgAction::SetTrue)]
+    #[arg(long, default_missing_value="true", num_args=0..=1)]
     allow_sockets: Option<bool>,
 
     // ENV
@@ -61,7 +61,7 @@ struct Args {
 
     // FS
     /// Allow unrestricted access to host preopens
-    #[arg(long, action = ArgAction::SetTrue, help_heading = "Fs")]
+    #[arg(long, default_missing_value="true", num_args=0..=1, help_heading = "Fs")]
     allow_fs: Option<bool>,
 
     /// Mount a virtual directory globbed from the local filesystem
@@ -74,7 +74,7 @@ struct Args {
 
     // STDIO
     /// Enable all stdio
-    #[arg(long, action = ArgAction::SetTrue, help_heading = "Stdio")]
+    #[arg(long, default_missing_value="true", num_args=0..=1, help_heading = "Stdio")]
     allow_stdio: Option<bool>,
     /// Configure all stdio
     #[arg(long, value_enum, value_name("cfg"), num_args(0..=1), require_equals(true), default_missing_value("allow"), help_heading = "Stdio")]


### PR DESCRIPTION
`ArgAction::SetTrue` is not the right action for `allow_xxx` options, as they should default to `None` instead of `Some(false)` when the option itself is not specified. The wrong default value led to the `--allow-all` option not being respected, as the `allow_xxx.unwrap_or(allow_all)` always ignored the `allow_all` value.