### PR TITLE
dep: Optionalize `wasm-opt` crate dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,9 @@ jobs:
     - name: Test
       run: cargo test
 
+    - name: Test without default features
+      run: cargo test --no-default-features
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ toml = "0.8"
 walrus = "0.20.3"
 wasm-compose = "0.5.5"
 wasm-metadata = "0.10.20"
-wasm-opt = "0.116.0"
+wasm-opt = { version = "0.116.0", optional = true }
 wit-component = "0.21.0"
 
 [build-dependencies]
@@ -51,3 +51,9 @@ wasmparser = "0.121.2"
 [workspace.dependencies]
 anyhow = "1"
 wit-bindgen = "0.25.0"
+
+[features]
+default = ["wasm-opt"]
+# Optimize the generated virtual adapter with wasm-opt to reduce its size.
+# If you allow all WASI subsystems, this feature doesn't make much difference.
+wasm-opt = ["dep:wasm-opt"]


### PR DESCRIPTION
The `wasm-opt` crate brings in C++ dependencies (binaryen) and it makes the build process more complex and slower (also setting up cross-compilation for C++ is not trivial unlike Rust). Also the DCE process doesn't make much difference if we allow all WASI subsystems.
This commit makes the `wasm-opt` crate dependency optional so that crate users can choose whether to use it or not.

Also strip the "name" section at walrus module generation time if `debug=false` because it was stripped by `wasm-opt` before.


## Data point

We use wasi-virt to embed Ruby installation package with `--allow-all`:

| wasm-opt=true | wasm-opt=false |
|:---------------:|:-----------------:|
| 28101333 | 28101048 (+285) |

At least for us, more 300 bytes to simplify build is fine.