### PR TITLE
Add dependabot periodic dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
wasm-tools and wit-bindgen are both quite active projects, and it's not easy to update them after long periods. This commit adds a dependabot configuration file to periodically update the dependencies to align with the latest toolchain.