### PR TITLE
toolchain: use wasm32-wasip1 target, remove nightly requirement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         submodules: recursive
 
     - name: Install Rust
-      run: rustup update nightly --no-self-update && rustup default nightly && rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+      run: rustup update stable --no-self-update && rustup default stable && rustup component add rust-src --toolchain stable
 
     - name: Install wasm32-unknown target
       run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,8 @@ jobs:
     - name: Install wasm32-unknown target
       run: rustup target add wasm32-unknown-unknown
 
-    - name: Install wasm32-wasi target
-      run: rustup target add wasm32-wasi
+    - name: Install wasm32-wasip1 target
+      run: rustup target add wasm32-wasip1
 
     - name: Install wasm-tools
       run: cargo install wasm-tools

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "nightly-2024-05-22"
-components = ["rust-src"]
-targets = ["wasm32-unknown-unknown"]

--- a/tests/virt.rs
+++ b/tests/virt.rs
@@ -97,7 +97,7 @@ async fn virt_test() -> Result<()> {
         let mut generated_component_path = generated_path.join(component_name);
         generated_component_path.set_extension("component.wasm");
         cmd(&format!(
-            "cargo build -p {component_name} --target wasm32-wasi {}",
+            "cargo build -p {component_name} --target wasm32-wasip1 {}",
             if DEBUG { "" } else { "--release" }
         ))?;
 
@@ -107,7 +107,7 @@ async fn virt_test() -> Result<()> {
 
         // encode the component
         let component_core_path = &format!(
-            "target/wasm32-wasi/{}/{}.wasm",
+            "target/wasm32-wasip1/{}/{}.wasm",
             if DEBUG { "debug" } else { "release" },
             component_name.to_snake_case()
         );


### PR DESCRIPTION
Removes the local `rust-toolchain.toml` and uses the `wasm32-wasip1` target.