### PR TITLE
Limit imported interfaces for composed components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,6 +1940,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wit-component",
+ "wit-parser 0.212.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ wasm-compose = "0.215.0"
 wasm-metadata = "0.212.0"
 wasm-opt = { version = "0.116.1", optional = true }
 wit-component = "0.212.0"
+wit-parser = "0.212.0"
 
 [build-dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ fn main() {
           ("host.txt", FsEntry::RuntimeFile("/runtime/host/path.txt"))
         ])));
 
+    // compose the virtualization with a component
+    virt.compose("path/to/component.wasm");
+    // filter enabled subsystems by imports on the composed component
+    virt.filter_imports().unwrap();
+
     let virt_component_bytes = virt.finish().unwrap();
     fs::write("virt.component.wasm", virt_component_bytes).unwrap();
 }
@@ -194,6 +199,8 @@ When calling a subsystem for the first time, its virtualization will be enabled.
 By default, when using the `wasi-virt` CLI command, all virtualizations are enabled. This way, not only is encapsulation the default, but composition with arbitrary components will always work out as all interfaces for WASI should always be available.
 
 Selective subsystem virtualization can be performed directly with the WASI Virt library as above (which does not virtualize all subsystems by default). This allows virtualizing just a single subsystem like `env`, where it is possible to virtualize only that subsystem and skip other virtualizations and end up creating a smaller virtualization component.
+
+When directly composing another component, individual subsystems are disabled if the composed component does not import that subsystem. This behavior reduces imports in the output component that are never actually used.
 
 There is an important caveat to this: _as soon as any subsystem uses IO, all subsystems using IO need to be virtualized in order to fully subclass streams and polls in the virtualization layer_. In future this caveat requirement should weaken as these features lower into the core ABI in subsequent WASI versions.
 

--- a/src/bin/wasi-virt.rs
+++ b/src/bin/wasi-virt.rs
@@ -1,8 +1,7 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use clap::{ArgAction, Parser};
-use std::{env, error::Error, fs, path::PathBuf, time::SystemTime};
+use std::{error::Error, fs, path::PathBuf};
 use wasi_virt::{StdioCfg, WasiVirt};
-use wasm_compose::composer::ComponentComposer;
 
 #[derive(Parser, Debug)]
 #[command(verbatim_doc_comment, author, version, about, long_about = None)]
@@ -104,20 +103,12 @@ where
     Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }
 
-fn timestamp() -> u64 {
-    match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(n) => n.as_secs(),
-        Err(_) => panic!(),
-    }
-}
-
 fn main() -> Result<()> {
     let args = Args::parse();
 
     let mut virt_opts = WasiVirt::default();
 
     virt_opts.debug = args.debug.unwrap_or_default();
-    virt_opts.compose = args.compose;
 
     // By default, we virtualize all subsystems
     // This ensures full encapsulation in the default (no argument) case
@@ -190,37 +181,14 @@ fn main() -> Result<()> {
         fs.allow_host_preopens();
     }
 
+    if let Some(compose) = args.compose {
+        virt_opts.compose(compose);
+        virt_opts.filter_imports()?;
+    }
+
     let virt_component = virt_opts.finish()?;
 
     let out_path = PathBuf::from(args.out);
-
-    let out_bytes = if let Some(compose_path) = virt_opts.compose {
-        let compose_path = PathBuf::from(compose_path);
-        let dir = env::temp_dir();
-        let tmp_virt = dir.join(format!("virt{}.wasm", timestamp()));
-        fs::write(&tmp_virt, virt_component.adapter)?;
-
-        let composed_bytes = ComponentComposer::new(
-            &compose_path,
-            &wasm_compose::config::Config {
-                definitions: vec![tmp_virt.clone()],
-                ..Default::default()
-            },
-        )
-        .compose()
-        .with_context(|| "Unable to compose virtualized adapter into component.\nMake sure virtualizations are enabled and being used.")
-        .or_else(|e| {
-            fs::remove_file(&tmp_virt)?;
-            Err(e)
-        })?;
-
-        fs::remove_file(&tmp_virt)?;
-
-        composed_bytes
-    } else {
-        virt_component.adapter
-    };
-
     if virt_component.virtual_files.len() > 0 {
         println!("Virtualized files from local filesystem:\n");
         for (virtual_path, original_path) in virt_component.virtual_files {
@@ -228,7 +196,7 @@ fn main() -> Result<()> {
         }
     }
 
-    fs::write(&out_path, out_bytes)?;
+    fs::write(&out_path, virt_component.adapter)?;
 
     Ok(())
 }

--- a/src/bin/wasi-virt.rs
+++ b/src/bin/wasi-virt.rs
@@ -117,6 +117,7 @@ fn main() -> Result<()> {
     let mut virt_opts = WasiVirt::default();
 
     virt_opts.debug = args.debug.unwrap_or_default();
+    virt_opts.compose = args.compose;
 
     // By default, we virtualize all subsystems
     // This ensures full encapsulation in the default (no argument) case
@@ -193,7 +194,7 @@ fn main() -> Result<()> {
 
     let out_path = PathBuf::from(args.out);
 
-    let out_bytes = if let Some(compose_path) = args.compose {
+    let out_bytes = if let Some(compose_path) = virt_opts.compose {
         let compose_path = PathBuf::from(compose_path);
         let dir = env::temp_dir();
         let tmp_virt = dir.join(format!("virt{}.wasm", timestamp()));

--- a/tests/cases/encapsulate-component.toml
+++ b/tests/cases/encapsulate-component.toml
@@ -1,0 +1,18 @@
+component = "do-everything"
+compose = true
+
+[virt-opts]
+clocks = true
+# http will be filtered out because the "do-everything" component doesn't import it
+http = true
+stdio.stdin = "ignore"
+stdio.stdout = "ignore"
+stdio.stderr = "ignore"
+
+[expect.imports]
+required = [
+   "wasi:clocks/wall-clock",
+]
+disallowed = [
+   "wasi:http/incoming-handler",
+]


### PR DESCRIPTION
Components that are directly composed will never use any virtualized interface that it does not already import. Virtualizing additional interfaces limits the compatibility of the resulting component as it places an additional requirement on the host environment to satisfy each import, used or not.

We now inspect the composed component to match the interfaces it imports with the virtualized capabilities. If the composed component does not import the respective interface the resulting component will not virtualize that interface. In effect, use of `--allow-all` will behave as if the caller specifically approved the interfaces actually used.

The granularity of filtered imports is coarse. Interfaces that support a consumed capability may still appear as imports even if the composed component does not consume them explicitly.

Refs https://github.com/bytecodealliance/WASI-Virt/pull/82#issuecomment-2292539512