### PR TITLE
Fixes the import filter string for clocks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ const IMPORT_FILTER_PREFIXES: [&str; 9] = [
     "wasi:config/store",
     "wasi:cli/std",
     "wasi:cli/terminal",
-    "wasi:cli/clocks",
+    "wasi:clocks/",
     "wasi:cli/exit",
     "wasi:http/",
     "wasi:sockets/",


### PR DESCRIPTION
When calling [`WasiVirt::filter_imports`](https://github.com/bytecodealliance/WASI-Virt/blob/146d1b0df9fb5fcdb6c566aaaca6bf1cb0e38614/src/lib.rs#L223), `WASI-Virt` loops through the constant `IMPORT_FILTER_PREFIXES`, checking to see whether a given interface ID matches the list of interfaces the system can filter out:

https://github.com/bytecodealliance/WASI-Virt/blob/146d1b0df9fb5fcdb6c566aaaca6bf1cb0e38614/src/lib.rs#L246-L250

However, there is a mismatch between the prefix entry for clocks:

https://github.com/bytecodealliance/WASI-Virt/blob/146d1b0df9fb5fcdb6c566aaaca6bf1cb0e38614/src/lib.rs#L107

(erroneously using the `cli` path segment) and the text being checked later in the same method:

https://github.com/bytecodealliance/WASI-Virt/blob/146d1b0df9fb5fcdb6c566aaaca6bf1cb0e38614/src/lib.rs#L272-L274

This PR updates the former to align with the latter.